### PR TITLE
[ADD] - Individual blog post metric dashboard feature

### DIFF
--- a/client/src/pages/dashboard/[slug]/index.jsx
+++ b/client/src/pages/dashboard/[slug]/index.jsx
@@ -1,0 +1,167 @@
+// IMPORT LIBRARIES
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Cookie from 'js-cookie';
+import { Link } from 'next/link';
+
+// IMPORT COMPONENTS
+import Layout from '../components/layout';
+
+export default function Page() {
+    const router = useRouter();
+    const adminToken = Cookie.get('token') || null;
+    const [blogPostMetrics, setBlogPostMetrics] = useState([]);
+    const [blogPostMetricsFetchLoading, setBlogPostMetricsFetchLoading] = useState(true);
+    const [blogPostMetricsFetchError, setBlogPostMetricsFetchError] = useState(false);
+    const [blogPostMetricsFetchErrorDetails, setBlogPostMetricsFetchErrorDetails] = useState(null);
+
+    const fetchBlogPostMetrics = async (slug) => {
+        try {
+            const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_ENDPOINT}/analytics/metrics/${slug}`, {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${adminToken}`
+                }
+            });
+
+            if (!response.ok) {
+                const errorDetails = await response.json();
+                setBlogPostMetricsFetchErrorDetails({
+                    statusCode: response.status,
+                    errorMessage: errorDetails?.message || errorDetails || "",
+                    errorDescription: errorDetails?.description || ""
+                });
+                setBlogPostMetricsFetchError(true);
+                setBlogPostMetricsFetchLoading(false);
+            }
+            const data = await response.json();
+            setBlogPostMetrics(data);
+            setBlogPostMetricsFetchLoading(false);
+
+        } catch (error) {
+            setBlogPostMetricsFetchErrorDetails({
+                statusCode: 400,
+                errorMessage: "Unexpected client error",
+                errorDescription: "Failed to fetch blog post metrics"
+            });
+            setBlogPostMetricsFetchError(true);
+            setBlogPostMetricsFetchLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (router.query.slug) {
+            fetchBlogPostMetrics(router.query.slug);
+        }
+    }, [router.query.slug]);
+
+    if (blogPostMetricsFetchLoading) {
+        return (
+            <div class="flex items-center justify-center h-96">
+                <div class="text-center">
+                    <p class="text-gray-500">Loading blog post metrics...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (!adminToken) {
+        router.push('/signin');
+    }
+
+    if (blogPostMetricsFetchError) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen">
+                <h1 className="text-4xl font-bold text-gray-900">{blogPostMetricsFetchErrorDetails.statusCode}: {blogPostMetricsFetchErrorDetails.errorMessage}</h1>
+                <p className="mt-4 text-lg text-gray-600">{blogPostMetricsFetchErrorDetails.errorDescription}</p>
+                <button 
+                    onClick={() => router.push('/signin')} 
+                    className="mt-8 px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600"
+                >
+                    Sign In
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div class="relative overflow-x-auto shadow-md sm:rounded-lg mb-8">
+            <table class="w-full text-sm text-left text-gray-500">
+                <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+                    <tr>
+                        <th scope="col" class="px-6 py-3">
+                            Blog Title
+                        </th>
+                        <th scope="col" class="px-6 py-3">
+                            <div class="flex items-center">
+                                Number of Views
+                            </div>
+                        </th>
+                        <th scope="col" class="px-6 py-3">
+                            <div class="flex items-center">
+                                Source - Email
+                            </div>
+                        </th>
+                        <th scope="col" class="px-6 py-3">
+                            <div class="flex items-center">
+                                Source - Direct
+                            </div>
+                        </th>
+                        <th scope="col" class="px-6 py-3">
+                            <div class="flex items-center">
+                                Source - Home
+                            </div>
+                        </th>
+                        <th scope="col" class="px-6 py-3">
+                            <div class="flex items-center">
+                                Number of Likes
+                            </div>
+                        </th>
+                        <th scope="col" class="px-6 py-3">
+                            <div class="flex items-center">
+                                Number of dislikes
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    <tr class="bg-white border-b">
+                        <th scope="row" class="px-6 py-4">
+                            {/* <Link href={`blog/${blogPostMetrics.blogId}`}> */}
+                                <a class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{blogPostMetrics.blogName}</a>
+                            {/* </Link> */}
+                        </th>
+                        <td class="px-6 py-4">
+                            {blogPostMetrics.uniqueVisit}
+                        </td>
+                        <td class="px-6 py-4">
+                            {blogPostMetrics.source && blogPostMetrics.source.email ? blogPostMetrics.source.email : 0}
+                        </td>
+                        <td class="px-6 py-4">
+                            {blogPostMetrics.source && blogPostMetrics.source.direct ? blogPostMetrics.source.direct : 0}
+                        </td>
+                        <td class="px-6 py-4">
+                            {blogPostMetrics.source && blogPostMetrics.source.home ? blogPostMetrics.source.home : 0}
+                        </td>
+                        <td class="px-6 py-4">
+                            {blogPostMetrics.likes || 0}
+                        </td>
+                        <td class="px-6 py-4">
+                            {blogPostMetrics.dislikes || 0}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+
+Page.getLayout = function getLayout(page) {
+    return (
+      <Layout>
+          {page}
+      </Layout>
+    )
+  }  

--- a/client/src/pages/dashboard/[slug]/index.jsx
+++ b/client/src/pages/dashboard/[slug]/index.jsx
@@ -131,7 +131,7 @@ export default function Page() {
                             <p class="font-medium text-gray-900 whitespace-nowrap">{blogPostMetrics.blogName}</p>
                         </th>
                         <td class="px-6 py-4">
-                            {blogPostMetrics.uniqueVisit}
+                            {blogPostMetrics.uniqueVisit || 0}
                         </td>
                         <td class="px-6 py-4">
                             {blogPostMetrics.source && blogPostMetrics.source.email ? blogPostMetrics.source.email : 0}

--- a/client/src/pages/dashboard/[slug]/index.jsx
+++ b/client/src/pages/dashboard/[slug]/index.jsx
@@ -128,9 +128,7 @@ export default function Page() {
                 <tbody>
                     <tr class="bg-white border-b">
                         <th scope="row" class="px-6 py-4">
-                            {/* <Link href={`blog/${blogPostMetrics.blogId}`}> */}
-                                <a class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{blogPostMetrics.blogName}</a>
-                            {/* </Link> */}
+                            <p class="font-medium text-gray-900 whitespace-nowrap">{blogPostMetrics.blogName}</p>
                         </th>
                         <td class="px-6 py-4">
                             {blogPostMetrics.uniqueVisit}

--- a/client/src/pages/dashboard/components/blogPostMetrics.jsx
+++ b/client/src/pages/dashboard/components/blogPostMetrics.jsx
@@ -58,15 +58,15 @@ const BlogPostMetrics = ({ adminToken }) => {
     }
 
     return (
-        <div class="relative overflow-x-auto shadow-md sm:rounded-lg mb-8">
-            <table class="w-full text-sm text-left text-gray-500">
-                <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+        <div className="relative overflow-x-auto shadow-md sm:rounded-lg mb-8">
+            <table className="w-full text-sm text-left text-gray-500">
+                <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                     <tr>
-                        <th scope="col" class="px-6 py-3">
+                        <th scope="col" className="px-6 py-3">
                             Blog Title
                         </th>
-                        <th scope="col" class="px-6 py-3">
-                            <div class="flex items-center">
+                        <th scope="col" className="px-6 py-3">
+                            <div className="flex items-center">
                                 Number of Views
                                 <div 
                                     onClick={() => sortBlogPostMetrics("uniqueVisit")}
@@ -75,8 +75,8 @@ const BlogPostMetrics = ({ adminToken }) => {
                                 </div>
                             </div>
                         </th>
-                        <th scope="col" class="px-6 py-3">
-                            <div class="flex items-center">
+                        <th scope="col" className="px-6 py-3">
+                            <div className="flex items-center">
                                 Source - Email
                                 <div 
                                     onClick={() => sortBlogPostMetrics("source", "email")}
@@ -85,8 +85,8 @@ const BlogPostMetrics = ({ adminToken }) => {
                                 </div>
                             </div>
                         </th>
-                        <th scope="col" class="px-6 py-3">
-                            <div class="flex items-center">
+                        <th scope="col" className="px-6 py-3">
+                            <div className="flex items-center">
                                 Source - Direct
                                 <div 
                                     onClick={() => sortBlogPostMetrics("source", "direct")}
@@ -95,8 +95,8 @@ const BlogPostMetrics = ({ adminToken }) => {
                                 </div>
                             </div>
                         </th>
-                        <th scope="col" class="px-6 py-3">
-                            <div class="flex items-center">
+                        <th scope="col" className="px-6 py-3">
+                            <div className="flex items-center">
                                 Source - Home
                                 <div 
                                     onClick={() => sortBlogPostMetrics("source", "home")}
@@ -105,8 +105,8 @@ const BlogPostMetrics = ({ adminToken }) => {
                                 </div>
                             </div>
                         </th>
-                        <th scope="col" class="px-6 py-3">
-                            <div class="flex items-center">
+                        <th scope="col" className="px-6 py-3">
+                            <div className="flex items-center">
                                 Number of Likes
                                 <div 
                                     onClick={() => sortBlogPostMetrics("likes")}
@@ -115,8 +115,8 @@ const BlogPostMetrics = ({ adminToken }) => {
                                 </div>
                             </div>
                         </th>
-                        <th scope="col" class="px-6 py-3">
-                            <div class="flex items-center">
+                        <th scope="col" className="px-6 py-3">
+                            <div className="flex items-center">
                                 Number of dislikes
                                 <div 
                                     onClick={() => sortBlogPostMetrics("dislikes")}
@@ -131,28 +131,28 @@ const BlogPostMetrics = ({ adminToken }) => {
                 <tbody>
                     {blogPostMetrics.map(item => {
                         return (
-                            <tr class="bg-white border-b">
-                                <th scope="row" class="px-6 py-4">
+                            <tr className="bg-white border-b">
+                                <th scope="row" className="px-6 py-4">
                                     <Link href={`/dashboard/${item.blogId}`}>
-                                        <p class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{item.blogName}</p>
+                                        <p className="font-medium text-blue-600 whitespace-nowrap hover:text-blue-900 hover:underline">{item.blogName}</p>
                                     </Link>
                                 </th>
-                                <td class="px-6 py-4">
+                                <td className="px-6 py-4">
                                     {item.uniqueVisit || 0}
                                 </td>
-                                <td class="px-6 py-4">
+                                <td className="px-6 py-4">
                                     {item.source.email || 0}
                                 </td>
-                                <td class="px-6 py-4">
+                                <td className="px-6 py-4">
                                     {item.source.direct || 0}
                                 </td>
-                                <td class="px-6 py-4">
+                                <td className="px-6 py-4">
                                     {item.source.home || 0}
                                 </td>
-                                <td class="px-6 py-4">
+                                <td className="px-6 py-4">
                                     {item.likes || 0}
                                 </td>
-                                <td class="px-6 py-4">
+                                <td className="px-6 py-4">
                                     {item.dislikes || 0}
                                 </td>
                             </tr>    

--- a/client/src/pages/dashboard/components/blogPostMetrics.jsx
+++ b/client/src/pages/dashboard/components/blogPostMetrics.jsx
@@ -4,52 +4,32 @@ import React, { useState, useEffect } from 'react';
 // IMPORT ICONS
 import SortButtonIcon from '@/assets/icons/sortButton';
 
-const BlogPostMetrics = () => {
+const BlogPostMetrics = ({ adminToken }) => {
     const [blogPostMetrics, setBlogPostMetrics] = useState([]);
     const [sortDirection, setSortDirection] = useState({ key: null, ascending: true });
 
     useEffect(() => {
-        const blogPostMetrics = [
-            {
-                id: "blog-post-id",
-                name: "Blog Post Title",
-                visits: 0,
-                likes: 0,
-                dislikes: 0,
-                source: {
-                    email: 0,
-                    direct: 0,
-                    home: 0
-                }
-            },
-            {
-                id: "blog-post-id",
-                name: "Blog Post Title",
-                visits: 5,
-                likes: 0,
-                dislikes: 0,
-                source: {
-                    email: 1,
-                    direct: 4,
-                    home: 0
-                }
-            },
-            {
-                id: "blog-post-id",
-                name: "Blog Post Title",
-                visits: 4,
-                likes: 0,
-                dislikes: 0,
-                source: {
-                    email: 0,
-                    direct: 7,
-                    home: 0
-                }
-            }
-        ];
+        const fetchBlogPostMetrics = async () => {
+            try {
+                const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_ENDPOINT}/analytics/metrics/bulk`, {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': `Bearer ${adminToken}`
+                    }
+                });
 
-        setBlogPostMetrics(blogPostMetrics);
-    }, []);
+                if (!response.ok) {
+                    throw new Error('Failed to fetch blog post metrics');
+                }
+                const data = await response.json();
+                setBlogPostMetrics(data);
+
+            } catch (error) {
+                console.error(error);
+            }
+        };
+        fetchBlogPostMetrics();
+    }, [adminToken]);
 
     const sortBlogPostMetrics = (key, subkey = null) => {
         let tempBlogPostMetrics = [...blogPostMetrics];
@@ -151,10 +131,10 @@ const BlogPostMetrics = () => {
                         return (
                             <tr class="bg-white border-b">
                                 <th scope="row" class="px-6 py-4">
-                                    <a href={`dashboard/${item.id}`} class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{item.name}</a>
+                                    <a href={`blog/${item.blogId}`} class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{item.blogName}</a>
                                 </th>
                                 <td class="px-6 py-4">
-                                    {item.visits}
+                                    {item.uniqueVisit}
                                 </td>
                                 <td class="px-6 py-4">
                                     {item.source.email}

--- a/client/src/pages/dashboard/components/blogPostMetrics.jsx
+++ b/client/src/pages/dashboard/components/blogPostMetrics.jsx
@@ -131,7 +131,7 @@ const BlogPostMetrics = ({ adminToken }) => {
                         return (
                             <tr class="bg-white border-b">
                                 <th scope="row" class="px-6 py-4">
-                                    <a href={`blog/${item.blogId}`} class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{item.blogName}</a>
+                                    <a href={`dashboard/${item.blogId}`} class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{item.blogName}</a>
                                 </th>
                                 <td class="px-6 py-4">
                                     {item.uniqueVisit}

--- a/client/src/pages/dashboard/components/blogPostMetrics.jsx
+++ b/client/src/pages/dashboard/components/blogPostMetrics.jsx
@@ -1,5 +1,6 @@
 // IMPORT LIBRARIES
 import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
 
 // IMPORT ICONS
 import SortButtonIcon from '@/assets/icons/sortButton';
@@ -131,7 +132,9 @@ const BlogPostMetrics = ({ adminToken }) => {
                         return (
                             <tr class="bg-white border-b">
                                 <th scope="row" class="px-6 py-4">
-                                    <a href={`dashboard/${item.blogId}`} class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{item.blogName}</a>
+                                    <Link href={`/dashboard/${item.blogId}`}>
+                                        <p class="font-medium text-gray-900 whitespace-nowrap hover:text-blue-900 hover:underline">{item.blogName}</p>
+                                    </Link>
                                 </th>
                                 <td class="px-6 py-4">
                                     {item.uniqueVisit}

--- a/client/src/pages/dashboard/components/blogPostMetrics.jsx
+++ b/client/src/pages/dashboard/components/blogPostMetrics.jsx
@@ -37,18 +37,19 @@ const BlogPostMetrics = ({ adminToken }) => {
         let newSortDirection = { key, ascending: true };
 
         if (key === "source") {
-            if (sortDirection.key === key && sortDirection.ascending) {
-                newSortDirection = { key, ascending: false };
-                tempBlogPostMetrics.sort((a, b) => a.source[subkey] - b.source[subkey]);
+            newSortDirection.key = `source-${subkey}`;
+            if (sortDirection.key === `source-${subkey}` && sortDirection.ascending) {
+                newSortDirection.ascending = false;
+                tempBlogPostMetrics.sort((a, b) => (a.source[subkey] ?? 0) - (b.source[subkey] ?? 0));
             } else {
-                tempBlogPostMetrics.sort((a, b) => b.source[subkey] - a.source[subkey]);
+                tempBlogPostMetrics.sort((a, b) => (b.source[subkey] ?? 0) - (a.source[subkey] ?? 0));
             }
         } else {
             if (sortDirection.key === key && sortDirection.ascending) {
-                newSortDirection = { key, ascending: false };
-                tempBlogPostMetrics.sort((a, b) => a[key] - b[key]);
+                newSortDirection.ascending = false;
+                tempBlogPostMetrics.sort((a, b) => (a[key] ?? 0) - (b[key] ?? 0));
             } else {
-                tempBlogPostMetrics.sort((a, b) => b[key] - a[key]);
+                tempBlogPostMetrics.sort((a, b) => (b[key] ?? 0) - (a[key] ?? 0));
             }
         }
 
@@ -68,7 +69,7 @@ const BlogPostMetrics = ({ adminToken }) => {
                             <div class="flex items-center">
                                 Number of Views
                                 <div 
-                                    onClick={() => sortBlogPostMetrics("visits")}
+                                    onClick={() => sortBlogPostMetrics("uniqueVisit")}
                                 >
                                     <SortButtonIcon />
                                 </div>
@@ -137,22 +138,22 @@ const BlogPostMetrics = ({ adminToken }) => {
                                     </Link>
                                 </th>
                                 <td class="px-6 py-4">
-                                    {item.uniqueVisit}
+                                    {item.uniqueVisit || 0}
                                 </td>
                                 <td class="px-6 py-4">
-                                    {item.source.email}
+                                    {item.source.email || 0}
                                 </td>
                                 <td class="px-6 py-4">
-                                    {item.source.direct}
+                                    {item.source.direct || 0}
                                 </td>
                                 <td class="px-6 py-4">
-                                    {item.source.home}
+                                    {item.source.home || 0}
                                 </td>
                                 <td class="px-6 py-4">
-                                    {item.likes}
+                                    {item.likes || 0}
                                 </td>
                                 <td class="px-6 py-4">
-                                    {item.dislikes}
+                                    {item.dislikes || 0}
                                 </td>
                             </tr>    
                         )

--- a/client/src/pages/dashboard/index.jsx
+++ b/client/src/pages/dashboard/index.jsx
@@ -99,7 +99,7 @@ export default function Page() {
             {dashboardMetrics && dashboardMetrics.uniqueVisit?.blog ?
                 <div>
                     <h1 className="text-3xl mb-4 font-normal tracking-tight text-gray-900">Blog Post Metrics</h1>
-                    <BlogPostMetrics />
+                    <BlogPostMetrics adminToken={adminToken}/>
 
                     <h1 className="text-3xl mb-4 font-normal tracking-tight text-gray-900">Unique visits to each blog page</h1>
                     <BarChart 


### PR DESCRIPTION
In this PR, the following issues and features are addressed.

1. The routing for the correct blog post in the `/dashboard` table is fixed.
2. Bulk blog post metrics frontend-backend integration is completed.
3. A `/dashboard/:blogId` frontend is created to further edit and view a neat metric dashboard for a particular blog post.

**Known Issue:**

- The `href` or `<Link>` for routing to the correct blog post from `/dashboard/:blogId` to `/blog/:blogId` is not functioning properly. Need some help with this.